### PR TITLE
EC-126: Replaced SilversolutionsDatatypesBundle with IbexaPlatformCommerceFieldTypesBundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,6 +72,7 @@
         "ezsystems/ezcommerce-price-engine": "^3.1@dev",
         "ezsystems/ezcommerce-admin-ui": "^1.0@dev",
         "ezsystems/ezcommerce-page-builder": "^1.0@dev",
+        "ezsystems/ezcommerce-fieldtypes": "^1.0@dev",
         "symfony/asset": "^5.0",
         "symfony/cache": "^5.0",
         "symfony/console": "^5.0",

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -66,7 +66,6 @@ return [
     Joli\ApacheTikaBundle\ApacheTikaBundle::class => ['all' => true],
     Siso\Bundle\OneSkyBundle\OneSkyBundle::class => ['all' => true],
     Silversolutions\Bundle\EshopBundle\SilversolutionsEshopBundle::class => ['all' => true],
-    Silversolutions\Bundle\DatatypesBundle\SilversolutionsDatatypesBundle::class => ['all' => true],
     Silversolutions\Bundle\ToolsBundle\SilversolutionsToolsBundle::class => ['all' => true],
     Silversolutions\Bundle\TranslationBundle\SilversolutionsTranslationBundle::class => ['all' => true],
     Siso\Bundle\EzStudioBundle\SisoEzStudioBundle::class => ['all' => true],
@@ -101,4 +100,5 @@ return [
     Ibexa\Commerce\Bundle\AdminUiBundle\IbexaCommerceAdminUiBundle::class => ['all' => true],
     Ibexa\Platform\Bundle\Commerce\PageBuilder\IbexaPlatformCommercePageBuilderBundle::class => ['all' => true],
     Ibexa\Platform\Bundle\Permissions\PlatformPermissionsBundle::class => ['all' => true],
+    Ibexa\Platform\Bundle\Commerce\FieldTypes\IbexaPlatformCommerceFieldTypesBundle::class => ['all' => true],
 ];

--- a/config/routes/ezcommerce.yaml
+++ b/config/routes/ezcommerce.yaml
@@ -5,9 +5,6 @@
 silversolutions_eshop:
     resource: "@SilversolutionsEshopBundle/Resources/config/ses_routing.yml"
     prefix: /
-silversolutions_datatypes:
-    resource: '@SilversolutionsDatatypesBundle/Resources/config/routing.yml'
-    prefix: /
 silversolutions_tools:
     resource: '@SilversolutionsToolsBundle/Resources/config/routing.yml'
     prefix: /


### PR DESCRIPTION
As mentioned in
https://github.com/ezsystems/ezcommerce-fieldtypes/pull/2

`SilversolutionsDatatypesBundle` is now obsolete.