### PR TITLE
EC-235: Aligned docker-compose setup with the changes from #28

### DIFF
--- a/doc/docker/solr.yml
+++ b/doc/docker/solr.yml
@@ -15,6 +15,7 @@ services:
     environment:
      - SEARCH_ENGINE=solr
      - SOLR_DSN=http://solr:8983
+     - SISO_SEARCH_SOLR_HOST=solr
 
   solr:
     build:

--- a/doc/docker/solr.yml
+++ b/doc/docker/solr.yml
@@ -14,7 +14,7 @@ services:
      - solr
     environment:
      - SEARCH_ENGINE=solr
-     - SOLR_DSN=http://solr:8983/solr
+     - SOLR_DSN=http://solr:8983
 
   solr:
     build:


### PR DESCRIPTION
This is a follow-up to [EC-235](https://jira.ez.no/browse/EC-235) and #28, aligning `docker-compose` setup with the changes.

* `SOLR_DSN` env var is related to eZ Platform by Ibexa Solr Bundle setup
* `SISO_SEARCH_SOLR_HOST` is related to Solarium setup

### QA
- [x] Regressions against #28 and #29
- [x] Test using `docker-compose`

### TODO
- [x] Test P.sh