### PR TITLE
[Solr] Aligned Solr setup with 7.7 changes

### DIFF
--- a/doc/docker/Dockerfile-solr
+++ b/doc/docker/Dockerfile-solr
@@ -1,26 +1,20 @@
-FROM solr:6-alpine
+FROM solr:7.7-alpine
 
 ARG SOLR_PORT=8983
 
 # Copy solr config from the version used by eZ Platform
-COPY vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/ /opt/solr/server/tmp
+COPY --chown=solr:solr ./migrations/solr/ /opt/solr/server/solr/configsets/ez
 
 # Prepare config
-RUN mkdir -p /opt/solr/server/ez/template \
- && cp -R /opt/solr/server/tmp/* /opt/solr/server/ez/template \
- && cp /opt/solr/server/solr/configsets/basic_configs/conf/currency.xml /opt/solr/server/ez/template \
- && cp /opt/solr/server/solr/configsets/basic_configs/conf/solrconfig.xml /opt/solr/server/ez/template \
- && cp /opt/solr/server/solr/configsets/basic_configs/conf/stopwords.txt /opt/solr/server/ez/template \
- && cp /opt/solr/server/solr/configsets/basic_configs/conf/synonyms.txt /opt/solr/server/ez/template \
- && cp /opt/solr/server/solr/configsets/basic_configs/conf/elevate.xml /opt/solr/server/ez/template \
- && cp /opt/solr/server/solr/solr.xml /opt/solr/server/ez \
- && sed -i.bak '/<updateRequestProcessorChain name="add-unknown-fields-to-the-schema">/,/<\/updateRequestProcessorChain>/d' /opt/solr/server/ez/template/solrconfig.xml \
- && sed -ie 's/${solr.autoSoftCommit.maxTime:-1}/${solr.autoSoftCommit.maxTime:20}/' /opt/solr/server/ez/template/solrconfig.xml
+RUN cp -R /opt/solr/server/solr/configsets/_default/conf/lang /opt/solr/server/solr/configsets/ez \
+ && cp /opt/solr/server/solr/configsets/_default/conf/solrconfig.xml /opt/solr/server/solr/configsets/ez \
+ && cp /opt/solr/server/solr/configsets/_default/conf/stopwords.txt /opt/solr/server/solr/configsets/ez \
+ && cp /opt/solr/server/solr/configsets/_default/conf/synonyms.txt /opt/solr/server/solr/configsets/ez \
+ && cp /opt/solr/example/example-DIH/solr/solr/conf/currency.xml /opt/solr/server/solr/configsets/ez \
+ && cp /opt/solr/server/solr/solr.xml /opt/solr/server/solr/configsets/ez \
+ && sed -i.bak '/<updateRequestProcessorChain name="add-unknown-fields-to-the-schema">/,/<\/updateRequestProcessorChain>/d' /opt/solr/server/solr/configsets/ez/solrconfig.xml \
+ && sed -ie 's/${solr.autoSoftCommit.maxTime:-1}/${solr.autoSoftCommit.maxTime:20}/' /opt/solr/server/solr/configsets/ez/solrconfig.xml
 
-# Set our core config as home
-ENV SOLR_HOME /opt/solr/server/ez
-
-RUN bin/solr -s ez -p $SOLR_PORT \
- && bin/solr create_core -c collection1 -d server/ez/template -p $SOLR_PORT \
- && bin/solr create_core -c econtent -d server/ez/template -p $SOLR_PORT \
- && bin/solr create_core -c econtent_back -d server/ez/template -p $SOLR_PORT
+RUN precreate-core collection1 /opt/solr/server/solr/configsets/ez \
+ && precreate-core econtent /opt/solr/server/solr/configsets/ez \
+ && precreate-core econtent_back /opt/solr/server/solr/configsets/ez

--- a/migrations/solr/schema.xml
+++ b/migrations/solr/schema.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE schema [
-<!ENTITY langfields SYSTEM "language-fieldtypes.xml">
-<!ENTITY customfields SYSTEM "custom-fields-types.xml">
-]>
+  <!ENTITY langfields SYSTEM "language-fieldtypes.xml">
+  <!ENTITY customfields SYSTEM "custom-fields-types.xml">
+  ]>
 <!--
 This is the Solr schema file. This file should be named "schema.xml" and should
 be in the conf directory under the solr home (i.e. ./solr/conf/schema.xml by
@@ -32,32 +32,63 @@ should not remove or drastically change the existing definitions.
       Default types by Solr. Will be reused for dynamic fields.
     -->
     <fieldType name="string" class="solr.TextField" sortMissingLast="true">
-      <analyzer type="index">
-        <tokenizer class="solr.KeywordTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-      </analyzer>
-      <analyzer type="query">
-        <tokenizer class="solr.KeywordTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-      </analyzer>
+        <analyzer type="index">
+            <tokenizer class="solr.KeywordTokenizerFactory"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+        </analyzer>
+        <analyzer type="query">
+            <tokenizer class="solr.KeywordTokenizerFactory"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+        </analyzer>
     </fieldType>
+
+    <fieldType name="text_general" class="solr.TextField" positionIncrementGap="100" multiValued="true" sortMissingLast="true">
+        <analyzer type="index">
+            <tokenizer class="solr.KeywordTokenizerFactory"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+        </analyzer>
+        <analyzer type="query">
+            <tokenizer class="solr.KeywordTokenizerFactory"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+        </analyzer>
+    </fieldType>
+
+    <fieldType name="pdate" class="solr.DatePointField" docValues="true"/>
+    <fieldType name="pdates" class="solr.DatePointField" docValues="true" multiValued="true"/>
+    <!--
+      Numeric field types that index values using KD-trees.
+      Point fields don't support FieldCache, so they must have docValues="true" if needed for sorting, faceting, functions, etc.
+    -->
+    <fieldType name="pint" class="solr.IntPointField" docValues="true"/>
+    <fieldType name="pfloat" class="solr.FloatPointField" docValues="true"/>
+    <fieldType name="plong" class="solr.LongPointField" docValues="true"/>
+    <fieldType name="pdouble" class="solr.DoublePointField" docValues="true"/>
+
+    <fieldType name="pints" class="solr.IntPointField" docValues="true" multiValued="true"/>
+    <fieldType name="pfloats" class="solr.FloatPointField" docValues="true" multiValued="true"/>
+    <fieldType name="plongs" class="solr.LongPointField" docValues="true" multiValued="true"/>
+    <fieldType name="pdoubles" class="solr.DoublePointField" docValues="true" multiValued="true"/>
+    <fieldType name="random" class="solr.RandomSortField" indexed="true"/>
+
     <fieldType name="identifier" class="solr.StrField" sortMissingLast="true" />
-    <fieldType name="boolean" class="solr.BoolField" sortMissingLast="true"/>
+    <fieldType name="boolean" class="solr.BoolField" sortMissingLast="true" multiValued="false"/>
+    <fieldType name="booleans" class="solr.BoolField" sortMissingLast="true" multiValued="true"/>
     <fieldtype name="binary" class="solr.BinaryField"/>
-    <fieldType name="int" class="solr.TrieIntField" precisionStep="0" positionIncrementGap="0"/>
-    <fieldType name="float" class="solr.TrieFloatField" precisionStep="0" positionIncrementGap="0"/>
-    <fieldType name="long" class="solr.TrieLongField" precisionStep="0" positionIncrementGap="0"/>
-    <fieldType name="double" class="solr.TrieDoubleField" precisionStep="0" positionIncrementGap="0"/>
-    <fieldType name="date" class="solr.TrieDateField" precisionStep="0" positionIncrementGap="0"/>
+    <fieldType name="int" class="solr.IntPointField" docValues="true"/>
+    <fieldType name="float" class="solr.FloatPointField" docValues="true"/>
+    <fieldType name="long" class="solr.LongPointField" docValues="true"/>
+    <fieldType name="double" class="solr.DoublePointField" docValues="true"/>
+    <fieldType name="date" class="solr.DatePointField" docValues="true"/>
 
     <fieldtype name="ignored" stored="false" indexed="false" multiValued="true" class="solr.StrField" />
     <fieldType name="point" class="solr.PointType" dimension="2" subFieldSuffix="_d"/>
     <fieldType name="location" class="solr.LatLonType" subFieldSuffix="_coordinate"/>
 
-    <fieldType name="currency" class="solr.CurrencyField" precisionStep="8" defaultCurrency="USD" currencyConfig="currency.xml" />
+    <fieldType name="solr_string" class="solr.StrField" />
 
-
-
+    <fieldType name="currency" class="solr.CurrencyFieldType"
+               amountLongSuffix="_l_ns" codeStrSuffix="_s_ns"
+               defaultCurrency="USD" currencyConfig="currency.xml" />
 
     <!--
       Required ID field.
@@ -102,6 +133,13 @@ should not remove or drastically change the existing definitions.
     <dynamicField name="*_gl_0_coordinate" type="double" indexed="true" stored="true"/>
     <dynamicField name="*_gl_1_coordinate" type="double" indexed="true" stored="true"/>
     <dynamicField name="*_c" type="currency" indexed="true" stored="true"/>
+    <dynamicField name="*_s_ns"  type="solr_string"  indexed="true"  stored="false" />
+    <dynamicField name="*_l_ns"  type="plong"   indexed="true"  stored="false"/>
+
+    <!--
+         This field is required to allow random sorting
+     -->
+    <dynamicField name="random*" type="random" indexed="true" stored="false"/>
 
     <!--
       This field is required since Solr 4


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | n/a
| **Type**                                   | bug
| **Target eZ Platform version** | `v3.1`
| **BC breaks**                          | no
| **Doc needed**                       | no

We've switched to Solr 7.7 (as the `./install-solr.sh` script would suggest), but never actually aligned `schema.xml` with what Solr Bundle for Solr 7.7 provides. Schema is custom because of some extra field(s), though in the future it would be good if it just included that custom field on top of Solr-bundle shipped schema. The easiest way would be to switch to managed schema...

As a bonus [the deprecated `solr.CurrencyField`](https://lucene.apache.org/solr/guide/7_7/working-with-currencies-and-exchange-rates.html#configuring-currencies) has been replaced with `solr.CurrencyFieldType`.

Moreover this PR fixes Solr Docker integration, which still had beeen running Solr 6.6.

### QA
- [x] The issue is visible when ran using Docker - with the eContent setup[1] the search (frontend) is not displaying any results. There should be an error logged containing the message  `undefined field ext_prefix_ngram`.
- [x] The issue of outdated schema applies to both standalone and Docker integrations, but might not be easily reproducible. Some features (like maybe random sort - a guess) should've not been working properly. Sanity tests then?
- [ ] P.sh

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).

---
[1] See internal Wiki