### PR TITLE
Fixed Solarium semantic configuration

### DIFF
--- a/config/packages/ezcommerce/ezcommerce.yaml
+++ b/config/packages/ezcommerce/ezcommerce.yaml
@@ -32,18 +32,3 @@ parameters:
         - siso_price.price_provider.shop
     siso_price.default.price_service_chain.bestseller_list:
         - siso_price.price_provider.shop
-
-
-nelmio_solarium:
-    endpoints:
-        default:
-            host: '%siso_search.solr.host%'
-            port: '%siso_search.solr.port%'
-            path: '%siso_search.solr.path%'
-            core: '%siso_search.solr.core%'
-            timeout: 30
-
-    clients:
-        default:
-            endpoints:
-                - default

--- a/config/packages/nelmio_solarium.yaml
+++ b/config/packages/nelmio_solarium.yaml
@@ -1,13 +1,13 @@
 nelmio_solarium:
     endpoints:
         default:
-            host: "%env(SOLR_HOST)%"
-            core: "%env(SOLR_CORE)%"
-            # The following are the default parameters for Solarium client:
-            # scheme: http
-            # port: 8983
-            # path: /solr
-            # timeout: 5
+            host: '%siso_search.solr.host%'
+            port: '%siso_search.solr.port%'
+            path: '%siso_search.solr.path%'
+            core: '%siso_search.solr.core%'
+            timeout: 30
+
     clients:
         default:
-            endpoints: [default]
+            endpoints:
+                - default


### PR DESCRIPTION
This is a follow-up to #34 which accidentally had overridden Commerce Solarium custom configuration. The best approach here is to move the config to the proper Symfony 5 place to avoid further regressions on accidental merge-ups.

### Steps to reproduce
1. Configure Ibexa Commerce with Solr on non-default host and/or port
    or
    Configure Ibexa Commerce on Platform.sh which by default uses non-default host and port
2. See that some features, like autosuggestion, are not working