### PR TITLE
Fixed wrong location id of translation folder

### DIFF
--- a/config/packages/ezcommerce/ecommerce_parameters.yaml
+++ b/config/packages/ezcommerce/ecommerce_parameters.yaml
@@ -10,7 +10,7 @@ parameters:
     ses_eshop.order.sales_contact: shop@silversolutions.de
     ses_eshop.lostorder_email: shop@silversolutions.de
     siso_paypal_payment.receiver_email: shop@silver.de
-    silver_tools.default.translationFolderId: 61 # root (1) / Components (59) / Textmodules (61)
+    silver_tools.default.translationFolderId: 62 # root (1) / Components (60) / Textmodules (62)
     siso_core.default.user_group_location: 106
     siso_core.default.user_group_location.business: 385
     siso_core.default.user_group_location.private: 388


### PR DESCRIPTION
In this place, an identifier of the translation folder was not changed. 

The issue can be reproduced in those steps:
- install ez commerce `composer create-project ezsystems/ezcommerce:3.2.0`
- change `APP_ENV=dev` to `APP_ENV=prod`
- enter frontend site of ez commerce
Then, in the footer should be displayed translation keys instead messages. 
