### PR TITLE
Dropped obsolete parameter referencing non-existent path

### DIFF
--- a/config/packages/ezcommerce/ecommerce_parameters.yaml
+++ b/config/packages/ezcommerce/ecommerce_parameters.yaml
@@ -25,7 +25,5 @@ parameters:
     siso_search.solr.core: '%env(SISO_SEARCH_SOLR_CORE)%'
     siso_search.solr.path: '%env(SISO_SEARCH_SOLR_PATH)%'
 
-    ezcommerce.installer.migration_files_path: '%kernel.project_dir%/migrations/demo'
-
     one_sky_api_key: my-one-sky-key
     one_sky_secret: my-onesky-password


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **Type**                                   | bug
| **Target Ibexa Commerce version** | `v3.2`+
| **BC breaks**                          | yes
| **Doc needed**                       | yes

### Description

This is a follow-up to #37 - dropping parameter referencing the dropped path.

### Doc

As described in ezsystems/ezcommerce-shop#196