### PR TITLE
Fixed size and color's index_field

### DIFF
--- a/config/packages/ezcommerce/ezcommerce_demo.yaml
+++ b/config/packages/ezcommerce/ezcommerce_demo.yaml
@@ -84,11 +84,11 @@ parameters:
         variant_color:
             filter_type: 'multi_or'
             sort_type: 'alpha'
-            index_field: 'ses_variant_farbe_ms'
+            index_field: 'ses_variant_color_ms'
         variant_size:
             filter_type: 'multi_or'
             sort_type: 'alpha'
-            index_field: 'ses_variant_groesse_ms'
+            index_field: 'ses_variant_size_ms'
         category:
             filter_type: 'multi_or'
             sort_type: 'alpha'


### PR DESCRIPTION
> JIRA: N/A

### Description 
Fix size and color's index_field according to `siso_core.default.variant_types` ids, Solr document fields and translation from German to English. When using a clean install and creating a product using the default variant types, this fix makes size and color facets available.

### Related PR
- https://github.com/ezsystems/ezcommerce-shop/pull/201

### Checklist

- [x] Code follows the code style of this project (use `$ composer fix-cs`).
- [ ] Change requires a change to the documentation.
- [x] Code is ready for a review.