### PR TITLE
Prepared branch for easier version upgrade

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,153 +1,63 @@
 {
-    "name": "ezsystems/ezcommerce",
-    "description": "eZ Commerce distribution",
-    "homepage": "https://github.com/ezsystems/ezcommerce",
-    "license": "proprietary",
     "type": "project",
-    "authors": [
-        {
-            "name": "eZ dev-team & eZ Community",
-            "homepage": "https://github.com/ezsystems/ezcommerce/contributors"
-        }
-    ],
-    "repositories": [
-        {
-            "type": "composer",
-            "url": "https://updates.ibexa.co"
-        }
-    ],
+    "license": "proprietary",
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "require": {
-        "php": "^7.3",
+        "php": ">=7.3",
         "ext-ctype": "*",
         "ext-iconv": "*",
-        "doctrine/doctrine-bundle": "^2.2.2",
+        "composer/package-versions-deprecated": "1.11.99.1",
+        "doctrine/annotations": "^1.0",
+        "doctrine/doctrine-bundle": "^2.2",
         "doctrine/doctrine-migrations-bundle": "^3.0",
-        "doctrine/orm": "^2.7.5",
-        "ezsystems/apache-tika-bundle": "^2.0",
-        "ezsystems/comment-bundle": "^3.1",
-        "ezsystems/date-based-publisher": "^4.3@dev",
-        "ezsystems/doctrine-dbal-schema": "^1.1@dev",
-        "ezsystems/ez-support-tools": "^2.3@dev",
-        "ezsystems/ezcommerce-admin-ui": "^1.2@dev",
-        "ezsystems/ezcommerce-base-design": "^3.3@dev",
-        "ezsystems/ezcommerce-checkout": "^1.0@dev",
-        "ezsystems/ezcommerce-erp-admin": "^3.3@dev",
-        "ezsystems/ezcommerce-fieldtypes": "^1.2@dev",
-        "ezsystems/ezcommerce-order-history": "^3.3@dev",
-        "ezsystems/ezcommerce-page-builder": "^1.2@dev",
-        "ezsystems/ezcommerce-price-engine": "^3.3@dev",
-        "ezsystems/ezcommerce-shop": "^3.3@dev",
-        "ezsystems/ezcommerce-shop-ui": "^1.1@dev",
-        "ezsystems/ezcommerce-transaction": "^1.0@dev",
-        "ezsystems/ezmigrationbundle": "^1.0@dev",
-        "ezsystems/ezplatform-admin-ui": "^2.3@dev",
-        "ezsystems/ezplatform-admin-ui-assets": "~5.3.0@beta",
-        "ezsystems/ezplatform-calendar": "^1.3@dev",
-        "ezsystems/ezplatform-connector-dam": "^1.1@dev",
-        "ezsystems/ezplatform-content-forms": "^1.3@dev",
-        "ezsystems/ezplatform-core": "^2.3@dev",
-        "ezsystems/ezplatform-cron": "^3.2@dev",
-        "ezsystems/ezplatform-design-engine": "^3.1@dev",
-        "ezsystems/ezplatform-ee-installer": "^3.3@dev",
-        "ezsystems/ezplatform-elastic-search-engine": "^1.2@dev",
-        "ezsystems/ezplatform-form-builder": "^2.3@dev",
-        "ezsystems/ezplatform-graphql": "^2.3@dev",
-        "ezsystems/ezplatform-http-cache": "^2.3@dev",
-        "ezsystems/ezplatform-http-cache-fastly": "^2.1@dev",
-        "ezsystems/ezplatform-icons": "~1.0.0@dev",
-        "ezsystems/ezplatform-kernel": "^1.3@dev",
-        "ezsystems/ezplatform-matrix-fieldtype": "^2.2@dev",
-        "ezsystems/ezplatform-page-builder": "^2.3@dev",
-        "ezsystems/ezplatform-page-fieldtype": "^2.3@dev",
-        "ezsystems/ezplatform-permissions": "^1.1@dev",
-        "ezsystems/ezplatform-personalization": "^1.0@dev",
-        "ezsystems/ezplatform-query-fieldtype": "^2.3@dev",
-        "ezsystems/ezplatform-rest": "^1.3@dev",
-        "ezsystems/ezplatform-richtext": "^2.3@dev",
-        "ezsystems/ezplatform-search": "^1.2@dev",
-        "ezsystems/ezplatform-segmentation": "^1.1@dev",
-        "ezsystems/ezplatform-site-factory": "^1.3@dev",
-        "ezsystems/ezplatform-solr-search-engine": "^3.3@dev",
-        "ezsystems/ezplatform-standard-design": "^0.4@dev",
-        "ezsystems/ezplatform-user": "^2.3@dev",
-        "ezsystems/ezplatform-version-comparison": "^1.3@dev",
-        "ezsystems/ezplatform-workflow": "^2.3@dev",
-        "ezsystems/job-queue-bundle": "^4.0",
-        "ezsystems/payment-core-bundle": "^3.0",
-        "ezsystems/stash-bundle": "^0.8",
-        "ezsystems/ezrecommendation-client": "^2.1@dev",
-        "friendsofsymfony/jsrouting-bundle": "^2.7",
-        "gregwar/captcha-bundle": "^2.1",
-        "hautelook/templated-uri-bundle": "^3.3",
-        "ibexa/image-editor": "^1.0@dev",
-        "ibexa/migrations": "^1.0@dev",
-        "ibexa/oauth2-client": "^1.0@dev",
-        "knplabs/knp-menu-bundle": "^3.1",
-        "lexik/jwt-authentication-bundle": "^2.10",
-        "monolog/monolog": "^2.1",
-        "php-http/guzzle6-adapter": "^2.0",
-        "platformsh/symfonyflex-bridge": "^2.2",
-        "sensio/framework-extra-bundle": "^5.6",
-        "symfony/asset": "^5.2.1",
-        "symfony/cache": "^5.2.1",
-        "symfony/console": "^5.2.1",
-        "symfony/doctrine-bridge": "v5.1.9",
-        "symfony/dotenv": "^5.2.1",
-        "symfony/expression-language": "^5.2.1",
-        "symfony/flex": "^1.10",
-        "symfony/form": "^5.2.1",
-        "symfony/framework-bundle": "^5.2.1",
-        "symfony/monolog-bundle": "^3.6",
-        "symfony/process": "^5.2.1",
-        "symfony/proxy-manager-bridge": "^5.2.1",
-        "symfony/security-bundle": "^5.2.1",
-        "symfony/serializer-pack": "^1.0",
-        "symfony/swiftmailer-bundle": "^3.5",
-        "symfony/thanks": "^1.2",
-        "symfony/translation": "^5.2.1",
-        "symfony/twig-bundle": "^5.2.1",
-        "symfony/validator": "^5.2.1",
-        "symfony/web-link": "^5.2.1",
-        "symfony/webpack-encore-bundle": "^1.8",
-        "symfony/yaml": "^5.2.1",
-        "twig/extra-bundle": "^3.1"
+        "doctrine/orm": "^2.8",
+        "phpdocumentor/reflection-docblock": "^5.2",
+        "sensio/framework-extra-bundle": "^5.6.1",
+        "symfony/asset": "5.2.*",
+        "symfony/console": "5.2.*",
+        "symfony/dotenv": "5.2.*",
+        "symfony/expression-language": "5.2.*",
+        "symfony/flex": "^1.11.0",
+        "symfony/form": "5.2.*",
+        "symfony/framework-bundle": "5.2.*",
+        "symfony/http-client": "5.2.*",
+        "symfony/intl": "5.2.*",
+        "symfony/mailer": "5.2.*",
+        "symfony/mime": "5.2.*",
+        "symfony/monolog-bundle": "^3.1",
+        "symfony/notifier": "5.2.*",
+        "symfony/process": "5.2.*",
+        "symfony/property-access": "5.2.*",
+        "symfony/property-info": "5.2.*",
+        "symfony/proxy-manager-bridge": "5.2.*",
+        "symfony/security-bundle": "5.2.*",
+        "symfony/serializer": "5.2.*",
+        "symfony/string": "5.2.*",
+        "symfony/translation": "5.2.*",
+        "symfony/twig-bundle": "^5.2",
+        "symfony/validator": "5.2.*",
+        "symfony/web-link": "5.2.*",
+        "symfony/yaml": "5.2.*",
+        "twig/extra-bundle": "^2.12|^3.0",
+        "twig/twig": "^2.12|^3.0"
     },
     "require-dev": {
-        "behat/behat": "^3.8",
-        "behat/mink": "^1.8",
-        "behat/mink-goutte-driver": "^1.2",
-        "behat/mink-selenium2-driver": "^1.4",
-        "bex/behat-screenshot": "^2.1",
-        "dmore/behat-chrome-extension": "^1.3",
-        "dmore/chrome-mink-driver": "^2.7",
-        "ezsystems/allure-behat": "^3.1.2@dev",
-        "ezsystems/allure-php-api": "^3.1.2@dev",
-        "ezsystems/behat-screenshot-image-driver-cloudinary": "^1.1@dev",
-        "ezsystems/behatbundle": "^8.3@dev",
-        "friends-of-behat/mink-browserkit-driver": "^1.4",
-        "friends-of-behat/mink-extension": "^2.4",
-        "friends-of-behat/symfony-extension": "^2.1",
-        "liuggio/fastest": "^1.7",
-        "overblog/graphiql-bundle": "^0.2",
-        "phpunit/phpunit": "^8.5",
-        "symfony/debug-pack": "^1.0",
-        "symfony/maker-bundle": "^1.24",
-        "symfony/test-pack": "^1.0"
+        "symfony/browser-kit": "^5.2",
+        "symfony/css-selector": "^5.2",
+        "symfony/debug-bundle": "^5.2",
+        "symfony/maker-bundle": "^1.26.1",
+        "symfony/phpunit-bridge": "^5.2",
+        "symfony/stopwatch": "^5.2",
+        "symfony/var-dumper": "^5.2",
+        "symfony/web-profiler-bundle": "^5.2"
     },
-    "conflict": {
-        "doctrine/persistence": "1.3.2",
-        "symfony/framework-bundle": "5.1.0",
-        "symfony/symfony": "*"
-    },
-    "replace": {
-        "ezsystems/ezstudio": "*",
-        "ezsystems/ezpublish-community": "*",
-        "paragonie/random_compat": "2.*",
-        "symfony/polyfill-ctype": "*",
-        "symfony/polyfill-iconv": "*",
-        "symfony/polyfill-php71": "*",
-        "symfony/polyfill-php70": "*",
-        "symfony/polyfill-php56": "*"
+    "config": {
+        "optimize-autoloader": true,
+        "preferred-install": {
+            "*": "dist"
+        },
+        "sort-packages": true
     },
     "autoload": {
         "psr-4": {
@@ -159,48 +69,37 @@
             "App\\Tests\\": "tests/"
         }
     },
+    "replace": {
+        "symfony/polyfill-ctype": "*",
+        "symfony/polyfill-iconv": "*",
+        "symfony/polyfill-php72": "*"
+    },
     "scripts": {
         "auto-scripts": {
             "cache:clear": "symfony-cmd",
-            "assets:install %PUBLIC_DIR%": "symfony-cmd",
-            "bazinga:js-translation:dump %PUBLIC_DIR%/assets --merge-domains": "symfony-cmd",
-            "yarn install": "script",
-            "ezplatform:encore:compile": "symfony-cmd"
+            "assets:install %PUBLIC_DIR%": "symfony-cmd"
         },
         "post-install-cmd": [
             "@auto-scripts"
         ],
         "post-update-cmd": [
             "@auto-scripts"
-        ],
-        "ezplatform-install": [
-            "@php bin/console --ansi ezplatform:install ezplatform-ee-clean",
-            "@php bin/console --ansi ezplatform:install ezcommerce-clean",
-            "@php bin/console --ansi ezplatform:graphql:generate-schema"
-        ],
-        "ezcommerce-install": [
-            "@ezplatform-install"
         ]
     },
-    "config": {
-        "preferred-install": {
-            "ezsystems/*": "dist"
-        },
-        "sort-packages": true,
-        "bin-dir": "bin/"
+    "conflict": {
+        "symfony/symfony": "*"
     },
     "extra": {
-        "ez-install-name": "eZ Commerce",
-        "ez-install-command": [
-            "bash install-solr.sh",
-            "composer ezcommerce-install"
-        ],
         "symfony": {
             "allow-contrib": true,
-            "require": "~5.2.1"
-        },
-        "branch-alias": {
-            "dev-master": "3.3.x-dev"
+            "require": "5.2.*",
+            "endpoint": "https://flex.ibexa.co"
+        }
+    },
+    "repositories": {
+        "ibexa": {
+            "type": "composer",
+            "url": "https://updates.ibexa.co"
         }
     }
 }

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -50,7 +50,6 @@ return [
     EzSystems\EzPlatformPageFieldTypeBundle\EzPlatformPageFieldTypeBundle::class => ['all' => true],
     EzSystems\EzPlatformFormBuilderBundle\EzPlatformFormBuilderBundle::class => ['all' => true],
     EzSystems\DateBasedPublisherBundle\EzSystemsDateBasedPublisherBundle::class => ['all' => true],
-    EzSystems\EzPlatformEnterpriseEditionInstallerBundle\EzPlatformEnterpriseEditionInstallerBundle::class => ['all' => true],
     EzSystems\EzPlatformWorkflowBundle\EzPlatformWorkflowBundle::class => ['all' => true],
     EzSystems\EzPlatformCalendarBundle\EzPlatformCalendarBundle::class => ['all' => true],
     EzSystems\EzPlatformSiteFactoryBundle\EzPlatformSiteFactoryBundle::class => ['all' => true],

--- a/upgrade/db/mysql/ezplatform-3.2.0-to-3.3.0.sql
+++ b/upgrade/db/mysql/ezplatform-3.2.0-to-3.3.0.sql
@@ -7,3 +7,6 @@ CREATE TABLE `ibexa_setting` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `ibexa_setting_group_identifier` (`group`, `identifier`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+
+INSERT INTO `ibexa_setting` (`group`, `identifier`, `value`)
+VALUES ('personalization', 'installation_key', '""');

--- a/upgrade/db/postgresql/ezplatform-3.2.0-to-3.3.0.sql
+++ b/upgrade/db/postgresql/ezplatform-3.2.0-to-3.3.0.sql
@@ -7,3 +7,6 @@ CREATE TABLE ibexa_setting (
   PRIMARY KEY (id),
   CONSTRAINT ibexa_setting_group_identifier UNIQUE ("group", identifier)
 );
+
+INSERT INTO "ibexa_setting" ("group", "identifier", "value")
+VALUES ('personalization', 'installation_key', '""');


### PR DESCRIPTION
The branch `v3.2-to-v3.3-upgrade` should be merged when doing a version upgrade to make the transition from v3.2 (metarepository installation) to v3.3 (flex project) easier.

It contains:
- Composer.json from ibexa/website-skeleton (https://github.com/ibexa/website-skeleton/blob/main/composer.json) so that our users don't have to apply the changes manually. *It's modified to use the `update.ibexa.co` server by default, so this step doesn't have to be applied manually*.
- removal of EzPlatformEnterpriseEditionInstallerBundle from bundles - this bundle is not used anymore and needs to be disabled, but it's not unconfigured by Composer during removal
 - Database upgrade scripts for the data present in Experience installer:
    https://github.com/ibexa/installer/blob/main/src/bundle/Resources/install/sql/mysql/user_settings.sql
    https://github.com/ibexa/installer/blob/main/src/bundle/Resources/install/sql/postgresql/user_settings.sql
    which are currently missing


Related:
https://github.com/ezsystems/ezplatform-ee/pull/188
https://github.com/ezsystems/ezplatform/pull/647